### PR TITLE
Contraseña en el objeto de autenticación

### DIFF
--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -63,6 +63,7 @@ router.post("/login", (req, res) => {
   let usuario = req.body.usuario;
   let contraseña = req.body.contraseña;
   myMongoLib
+  //Para hallar el usuario no es necesario pasar la contraseña en el objeto
     .findUser({
       usuario: usuario,
       contraseña: contraseña


### PR DESCRIPTION
No se necesita la llave/valor de contraseña en el objeto que busca usuarios dentro del proceso de autenticación