### PR TITLE
API KEY!

### DIFF
--- a/front/src/components/GoogleMap/GoogleMap.jsx
+++ b/front/src/components/GoogleMap/GoogleMap.jsx
@@ -33,6 +33,7 @@ class SimpleMap extends Component {
         alt="lo que sea"
       >
         <GoogleMapReact
+          //OJO CON EL API KEY!!!!!! 
           bootstrapURLKeys={{ key: "AIzaSyBQGovuMsVwP-HAiTWrNAVND5JfnikoPZ8" }}
           defaultCenter={{ lat: this.props.lat, lng: this.props.lon }}
           defaultZoom={17}


### PR DESCRIPTION
El api key de Google Maps está expuesta! Alguien externo podría consumir muy fácil de ella y por eso es recomendable que esté restringida a servicio (que solo sirva para el API de Directions de Google Maps, por ejemplo) y a url de petición (que solo sirva desde su dominio en Heroku, por ejemplo).